### PR TITLE
Workaround for segmentation faults

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,37 @@ Now start ZeroTier:
 
 ## Compiling from Sources
 
+### Feed
+A working OpenWRT/LEDE build enviroment is expected (else see below).
+
+Put this line in your feed definition (eg. feeds.conf.default)
+```
+src-git zerotier https://github.com/muebau/zerotier-openwrt.git
+```
+
+Update the feeds
+```
+./scripts/feeds update
+```
+
+Make sure the package is in the feeds now
+```
+./scripts/feeds search zerotier
+```
+
+Install the package
+```
+./scripts/feeds install zerotier
+```
+
+Select and build the package
+```
+make menuconfig
+make
+```
+
+### The other way
+
 To inlcude ZeroTier One into your OpenWRT image or to create
 an .ipk package (equivalent to Debians .deb files),
 you have to build an OpenWRT image.

--- a/zerotier/patches/0003-workaround_to_avoid_seg_faults.patch
+++ b/zerotier/patches/0003-workaround_to_avoid_seg_faults.patch
@@ -1,0 +1,27 @@
+From 21f4958bd48cae59b478b1b3445e00fa4fb18991 Mon Sep 17 00:00:00 2001
+From: muebau <muebau@gmail.com>
+Date: Fri, 5 Aug 2016 19:22:45 +0200
+Subject: [PATCH] OpenWRT workaround to avoid seg faults
+
+---
+ service/OneService.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/service/OneService.cpp b/service/OneService.cpp
+index 13820f5..9ba3238 100644
+--- a/service/OneService.cpp
++++ b/service/OneService.cpp
+@@ -862,8 +862,8 @@ public:
+ 			}
+ 
+ 			// Start two background threads to handle expensive ops out of line
+-			Thread::start(_node);
+-			Thread::start(_node);
++			//Thread::start(_node);
++			//Thread::start(_node);
+ 
+ 			_nextBackgroundTaskDeadline = 0;
+ 			uint64_t clockShouldBe = OSUtils::now();
+-- 
+2.7.4
+


### PR DESCRIPTION
I provided a little patch file based on the suggestions of @adamierymenko in #9. The readme was extended to reflect installations based on feeds too.