### PR TITLE
Fixed /etc/ typo

### DIFF
--- a/zerotier/files/etc/init.d/zerotier
+++ b/zerotier/files/etc/init.d/zerotier
@@ -18,7 +18,7 @@ start_instance() {
 	local args=""
 
 	if ! section_enabled "$cfg"; then
-		echo "disabled in /ect/config/zerotier"
+		echo "disabled in /etc/config/zerotier"
 		return 1
 	fi
 


### PR DESCRIPTION
Fixed a typo when the config file errors. From /ect/ to /etc/