### PR TITLE
zerotier: add support for allowDefault and others

### DIFF
--- a/zerotier/files/etc/init.d/zerotier
+++ b/zerotier/files/etc/init.d/zerotier
@@ -14,7 +14,7 @@ section_enabled() {
 
 start_instance() {
 	local cfg="$1"
-	local port secret config_path local_conf copy_config_path path
+	local port secret config_path local_conf copy_config_path path allow_managed allow_global allow_default allow_dns
 	local args=""
 
 	if ! section_enabled "$cfg"; then
@@ -27,6 +27,10 @@ start_instance() {
 	config_get secret $cfg 'secret'
 	config_get local_conf $cfg 'local_conf'
 	config_get_bool copy_config_path $cfg 'copy_config_path' 0
+	config_get allow_managed $cfg 'allowManaged'
+	config_get allow_global $cfg 'allowGlobal'
+	config_get allow_default $cfg 'allowDefault'
+	config_get allow_dns $cfg 'allowDNS'
 
 	path=${CONFIG_PATH}_$cfg
 
@@ -87,6 +91,20 @@ start_instance() {
 	add_join() {
 		# an (empty) config file will cause ZT to join a network
 		touch $path/networks.d/$1.conf
+
+		# create a corresponding .local.conf file if any of it's settings exist.
+                if [ $allow_managed ]; then
+			echo "allowManaged=$allow_managed" >> $path/networks.d/$1.local.conf
+		fi
+                if [ $allow_global ]; then
+			echo "allowGlobal=$allow_global" >> $path/networks.d/$1.local.conf
+		fi
+                if [ $allow_default ]; then
+			echo "allowDefault=$allow_default" >> $path/networks.d/$1.local.conf
+		fi
+                if [ $allow_dns ]; then
+			echo "allowDNS=$allow_dns" >> $path/networks.d/$1.local.conf
+		fi
 	}
 
 	config_list_foreach $cfg 'join' add_join

--- a/zerotier/files/etc/init.d/zerotier
+++ b/zerotier/files/etc/init.d/zerotier
@@ -27,10 +27,6 @@ start_instance() {
 	config_get secret $cfg 'secret'
 	config_get local_conf $cfg 'local_conf'
 	config_get_bool copy_config_path $cfg 'copy_config_path' 0
-	config_get allow_managed $cfg 'allowManaged'
-	config_get allow_global $cfg 'allowGlobal'
-	config_get allow_default $cfg 'allowDefault'
-	config_get allow_dns $cfg 'allowDNS'
 
 	path=${CONFIG_PATH}_$cfg
 
@@ -90,22 +86,32 @@ start_instance() {
 
 	add_join() {
 		# an (empty) config file will cause ZT to join a network
-		touch $path/networks.d/$1.conf
+
+		ZTnetwork=$(echo "$1" | cut -d ',' -f 1 )
+		PARAMS=$( echo "$1" | cut -d ',' -f 2-6)
+
+		touch $path/networks.d/$ZTnetwork.conf
+
+		# split the paramters into individual lines for easier parsing.
+		# we just need the value of what the specific paramter equels to.
+		allow_managed=$( echo "$PARAMS" | tr ',' '\n' | grep -w "allowManaged" | sed 's/^.*=//' )
+		allow_glabal=$( echo "$PARAMS" | tr ',' '\n' | grep -w "allowGlobal" | sed 's/^.*=//' )
+		allow_default=$( echo "$PARAMS" | tr ',' '\n' | grep -w "allowDefault" | sed 's/^.*=//' )
+		allow_dns=$( echo "$PARAMS" | tr ',' '\n' | grep -w "allowDNS" | sed 's/^.*=//' )
 
                 # create a corresponding .local.conf file if any of it's settings exist.
                 if [ $allow_managed ] && [ -n $allow_managed ]; then
-                        echo "allowManaged=$allow_managed" >> $path/networks.d/$1.local.conf
+                        echo "allowManaged=$allow_managed" >> $path/networks.d/$ZTnetwork.local.conf
                 fi
                 if [ $allow_global ] && [ -n allow_managed ]; then
-                        echo "allowGlobal=$allow_global" >> $path/networks.d/$1.local.conf
+                        echo "allowGlobal=$allow_global" >> $path/networks.d/$ZTnetwork.local.conf
                 fi
                 if [ $allow_default ] && [ allow_default ]; then
-                        echo "allowDefault=$allow_default" >> $path/networks.d/$1.local.conf
+                        echo "allowDefault=$allow_default" >> $path/networks.d/$ZTnetwork.local.conf
                 fi
                 if [ $allow_dns ] && [ -n allowd_dns ]; then
-                        echo "allowDNS=$allow_dns" >> $path/networks.d/$1.local.conf
+                        echo "allowDNS=$allow_dns" >> $path/networks.d/$ZTnetwork.local.conf
                 fi
-
 	}
 
 	config_list_foreach $cfg 'join' add_join

--- a/zerotier/files/etc/init.d/zerotier
+++ b/zerotier/files/etc/init.d/zerotier
@@ -14,7 +14,7 @@ section_enabled() {
 
 start_instance() {
 	local cfg="$1"
-	local port secret config_path local_conf copy_config_path path allow_managed allow_global allow_default allow_dns
+	local port secret config_path local_conf copy_config_path path
 	local args=""
 
 	if ! section_enabled "$cfg"; then
@@ -84,34 +84,30 @@ start_instance() {
 		ln -s "$local_conf" $path/local.conf
 	fi
 
+	add_join_local() {
+
+		# split the parameters into individual lines for easier parsing.
+		# we just need the value of what the specific parameter equels to.
+
+		local params=$( echo "$1" | cut -d ',' -f 2-)
+
+		local allow_val=$( echo "$params" | tr ',' '\n' | grep -w "$2" | sed 's/^.*=//' )
+                if [ $allow_val ] && [ -n allow_val ]; then
+                        echo "$2=$allow_val" >> $path/networks.d/$ZTnetwork.local.conf
+                fi
+	}
+
 	add_join() {
 		# an (empty) config file will cause ZT to join a network
 
-		ZTnetwork=$(echo "$1" | cut -d ',' -f 1 )
-		PARAMS=$( echo "$1" | cut -d ',' -f 2-6)
+		local ZTnetwork=$(echo "$1" | cut -d ',' -f 1 )
 
 		touch $path/networks.d/$ZTnetwork.conf
 
-		# split the paramters into individual lines for easier parsing.
-		# we just need the value of what the specific paramter equels to.
-		allow_managed=$( echo "$PARAMS" | tr ',' '\n' | grep -w "allowManaged" | sed 's/^.*=//' )
-		allow_glabal=$( echo "$PARAMS" | tr ',' '\n' | grep -w "allowGlobal" | sed 's/^.*=//' )
-		allow_default=$( echo "$PARAMS" | tr ',' '\n' | grep -w "allowDefault" | sed 's/^.*=//' )
-		allow_dns=$( echo "$PARAMS" | tr ',' '\n' | grep -w "allowDNS" | sed 's/^.*=//' )
-
-                # create a corresponding .local.conf file if any of it's settings exist.
-                if [ $allow_managed ] && [ -n $allow_managed ]; then
-                        echo "allowManaged=$allow_managed" >> $path/networks.d/$ZTnetwork.local.conf
-                fi
-                if [ $allow_global ] && [ -n allow_managed ]; then
-                        echo "allowGlobal=$allow_global" >> $path/networks.d/$ZTnetwork.local.conf
-                fi
-                if [ $allow_default ] && [ allow_default ]; then
-                        echo "allowDefault=$allow_default" >> $path/networks.d/$ZTnetwork.local.conf
-                fi
-                if [ $allow_dns ] && [ -n allowd_dns ]; then
-                        echo "allowDNS=$allow_dns" >> $path/networks.d/$ZTnetwork.local.conf
-                fi
+		add_join_local $1 "allowManaged"
+		add_join_local $1 "allowGlobal"
+		add_join_local $1 "allowDefault"
+		add_join_local $1 "allowDNS"
 	}
 
 	config_list_foreach $cfg 'join' add_join

--- a/zerotier/files/etc/init.d/zerotier
+++ b/zerotier/files/etc/init.d/zerotier
@@ -92,19 +92,20 @@ start_instance() {
 		# an (empty) config file will cause ZT to join a network
 		touch $path/networks.d/$1.conf
 
-		# create a corresponding .local.conf file if any of it's settings exist.
-                if [ $allow_managed ]; then
-			echo "allowManaged=$allow_managed" >> $path/networks.d/$1.local.conf
-		fi
-                if [ $allow_global ]; then
-			echo "allowGlobal=$allow_global" >> $path/networks.d/$1.local.conf
-		fi
-                if [ $allow_default ]; then
-			echo "allowDefault=$allow_default" >> $path/networks.d/$1.local.conf
-		fi
-                if [ $allow_dns ]; then
-			echo "allowDNS=$allow_dns" >> $path/networks.d/$1.local.conf
-		fi
+                # create a corresponding .local.conf file if any of it's settings exist.
+                if [ $allow_managed ] && [ -n $allow_managed ]; then
+                        echo "allowManaged=$allow_managed" >> $path/networks.d/$1.local.conf
+                fi
+                if [ $allow_global ] && [ -n allow_managed ]; then
+                        echo "allowGlobal=$allow_global" >> $path/networks.d/$1.local.conf
+                fi
+                if [ $allow_default ] && [ allow_default ]; then
+                        echo "allowDefault=$allow_default" >> $path/networks.d/$1.local.conf
+                fi
+                if [ $allow_dns ] && [ -n allowd_dns ]; then
+                        echo "allowDNS=$allow_dns" >> $path/networks.d/$1.local.conf
+                fi
+
 	}
 
 	config_list_foreach $cfg 'join' add_join


### PR DESCRIPTION
Hi,

This is the the code I added to /etc/init.d/zerotier.  it’s just adding variables, performing a config_get for them.  
The clever bit is in add_join, where it simply writes these var’s to the network’s local.conf if the vars are present.   This is safe because any preexisting local.conf is already deleted!

