### PR TITLE
Improves configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ opkg install zerotier_*.ipk
 Now enable ZeroTier:
 
 ```
-uci set zerotier.sample_config.enabled='1'
+uci set zerotier.global.enabled='1'
 uci commit zerotier
 ```
 

--- a/zerotier/files/etc/config/zerotier
+++ b/zerotier/files/etc/config/zerotier
@@ -1,20 +1,39 @@
 
-config zerotier sample_config
+config zerotier 'global'
+	# Sets whether ZeroTier is enabled or not
 	option enabled 0
-
-	# persistent configuration folder (for ZT controller mode)
+	# Sets the ZeroTier listening port (default 9993; set to 0 for random)
+	#option port '9993'
+	# Client secret (leave blank to generate a secret on first run)
+	option secret ''
+	# Path of the optional file local.conf (see documentation at
+	# https://docs.zerotier.com/config#local-configuration-options)
+	#option local_conf_path '/etc/zerotier.conf'
+	# Persistent configuration directory (to perform other configurations such
+	# as controller mode or moons, etc.)
 	#option config_path '/etc/zerotier'
-	# copy <config_path> to RAM to prevent writing to flash (for ZT controller mode)
+	# Copy the contents of the persistent configuration directory to memory
+	# instead of linking it, this avoids writing to flash
 	#option copy_config_path '1'
 
-	#option port '9993'
+# Network configuration, you can have as many configurations as networks you
+# want to join (the network name is optional)
+config network 'mynet'
+	# Identifier of the network you wish to join
+	option id '8056c2e21c000001'
+	# Network configuration parameters (all are optional, if not indicated the
+	# default values are set, see documentation at
+	# https://docs.zerotier.com/config/#network-specific-configuration)
+	option allow_managed '1'
+	option allow_global '0'
+	option allow_default '0'
+	option allow_dns '0'
 
-	# path to the local.conf
-	#option local_conf '/etc/zerotier.conf'
+# Example of a second network (unnamed as it is optional)
+#config network
+#	option id '1234567890123456'
+#	option allow_managed '1'
+#	option allow_global '0'
+#	option allow_default '0'
+#	option allow_dns '0'
 
-	# Generate secret on first start
-	option secret ''
-
-	# Join a public network called Earth
-	list join '8056c2e21c000001'
-	#list join '<other_network>'

--- a/zerotier/files/etc/init.d/zerotier
+++ b/zerotier/files/etc/init.d/zerotier
@@ -7,113 +7,94 @@ USE_PROCD=1
 PROG=/usr/bin/zerotier-one
 CONFIG_PATH=/var/lib/zerotier-one
 
-section_enabled() {
-	config_get_bool enabled "$1" 'enabled' 0
-	[ $enabled -ne 0 ]
+join_network() {
+	local section="${1}"
+	local id allow_managed allow_global allow_default allow_dns
+
+	config_get id "${section}" 'id'
+	config_get_bool allow_managed "${section}" 'allow_managed' 1
+	config_get_bool allow_global "${section}" 'allow_global' 0
+	config_get_bool allow_default "${section}" 'allow_default' 0
+	config_get_bool allow_dns "${section}" 'allow_dns' 0
+
+	if [ -n "${id}" ]; then
+		# an (empty) config file will cause ZT to join a network
+		touch "${CONFIG_PATH}"/networks.d/"${id}".conf
+		echo "allowManaged=${allow_managed}" > "${CONFIG_PATH}"/networks.d/"${id}".local.conf
+		echo "allowGlobal=${allow_global}" >> "${CONFIG_PATH}"/networks.d/"${id}".local.conf
+		echo "allowDefault=${allow_default}" >> "${CONFIG_PATH}"/networks.d/"${id}".local.conf
+		echo "allowDNS=${allow_dns}" >> "${CONFIG_PATH}"/networks.d/"${id}".local.conf
+	fi
 }
 
-start_instance() {
-	local cfg="$1"
-	local port secret config_path local_conf copy_config_path path
+start_service() {
+	config_load zerotier
+	local enabled port secret local_conf_path config_path copy_config_path
 	local args=""
 
-	if ! section_enabled "$cfg"; then
+	config_get_bool enabled 'global' 'enabled' 0
+	config_get port 'global' 'port'
+	config_get secret 'global' 'secret'
+	config_get local_conf_path 'global' 'local_conf_path'
+	config_get config_path 'global' 'config_path'
+	config_get_bool copy_config_path 'global' 'copy_config_path' 0
+
+	if [ ${enabled} -eq 0 ]; then
 		echo "disabled in /etc/config/zerotier"
-		return 1
 	fi
 
-	config_get config_path $cfg 'config_path'
-	config_get port $cfg 'port'
-	config_get secret $cfg 'secret'
-	config_get local_conf $cfg 'local_conf'
-	config_get_bool copy_config_path $cfg 'copy_config_path' 0
-
-	path=${CONFIG_PATH}_$cfg
-
 	# Remove existing link or folder
-	rm -rf $path
+	rm -rf "${CONFIG_PATH}"
 
-	# Create link or copy files from CONFIG_PATH to config_path
-	if [ -n "$config_path" -a "$config_path" != "$path" ]; then
-		if [ ! -d "$config_path" ]; then
-			echo "ZeroTier config_path does not exist: $config_path" 1>&2
+	# Create link or copy files from config_path to CONFIG_PATH
+	if [ -n "${config_path}" -a "${config_path}" != "${path}" ]; then
+		if [ ! -d "${config_path}" ]; then
+			echo "ZeroTier config_path does not exist: ${config_path}" 1>&2
 			return
 		fi
 
-		# ensure that the target exists
-		mkdir -p $(dirname $path)
-
-		if [ "$copy_config_path" = "1" ]; then
-			cp -r $config_path $path
+		if [ ${copy_config_path} -eq 1 ]; then
+			cp -r "${config_path}" "${CONFIG_PATH}"
 		else
-			ln -s $config_path $path
+			ln -s "${config_path}" "${CONFIG_PATH}"
 		fi
 	fi
 
-	mkdir -p $path/networks.d
-
-	# link latest default config path to latest config path
-	rm -f $CONFIG_PATH
-	ln -s $path $CONFIG_PATH
-
-	if [ -n "$port" ]; then
-		args="$args -p${port}"
+	if [ -f "${local_conf_path}" ]; then
+		ln -s "${local_conf_path}" "${CONFIG_PATH}"/local.conf
 	fi
 
-	if [ -z "$secret" ]; then
-		echo "Generate secret - please wait..."
-		local sf="/tmp/zt.$cfg.secret"
+	if [ -n "${port}" ]; then
+		args="${args} -p${port}"
+	fi
 
-		zerotier-idtool generate "$sf" > /dev/null
-		[ $? -ne 0 ] && return 1
-
-		secret="$(cat $sf)"
-		rm "$sf"
-
-		uci set zerotier.$cfg.secret="$secret"
+	if [ -z "${secret}" ]; then
+		echo -n "Generating secret - please wait... "
+		secret="$(zerotier-idtool generate)"
+		[ ${?} -ne 0 ] && return 1
+		uci set zerotier.global.secret="${secret}"
 		uci commit zerotier
+		echo "done."
 	fi
 
-	if [ -n "$secret" ]; then
-		echo "$secret" > $path/identity.secret
+	if [ -n "${secret}" ]; then
+		echo "${secret}" > "${CONFIG_PATH}"/identity.secret
 		# make sure there is not previous identity.public
-		rm -f $path/identity.public
+		rm -f "${CONFIG_PATH}"/identity.public
 	fi
 
-	if [ -f "$local_conf" ]; then
-		ln -s "$local_conf" $path/local.conf
-	fi
-
-	add_join() {
-		# an (empty) config file will cause ZT to join a network
-		touch $path/networks.d/$1.conf
-	}
-
-	config_list_foreach $cfg 'join' add_join
+	mkdir -p "${CONFIG_PATH}"/networks.d
+	config_foreach join_network network
 
 	procd_open_instance
-	procd_set_param command $PROG $args $path
+	procd_set_param command ${PROG} ${args}
 	procd_set_param stderr 1
 	procd_set_param respawn
 	procd_close_instance
 }
 
-start_service() {
-	config_load 'zerotier'
-	config_foreach start_instance 'zerotier'
-}
-
-stop_instance() {
-	local cfg="$1"
-
-	# Remove existing link or folder
-	rm -rf ${CONFIG_PATH}_${cfg}
-}
-
 stop_service() {
-	config_load 'zerotier'
-	config_foreach stop_instance 'zerotier'
-	rm -f ${CONFIG_PATH}
+	rm -rf "${CONFIG_PATH}"
 }
 
 reload_service() {


### PR DESCRIPTION
As discussed in #119 it may be time to change the ZeroTier configuration file slightly to support a number of global options and a number of per-network options. This way the startup script is slightly simplified and more configuration items can be specified per network.

Note that although this makes the current configurations incompatible, it is not a problem since you are supposed to review the configuration changes with each update. It also greatly improves the understanding of the configuration itself and opens up new possibilities in the future.