### PR TITLE
Adds new config migration script

### DIFF
--- a/zerotier/files/etc/uci-defaults/80-zt-migration
+++ b/zerotier/files/etc/uci-defaults/80-zt-migration
@@ -14,4 +14,4 @@ uci rename zerotier.@zerotier[0].local_conf='local_conf_path' \
 uci rename zerotier.@zerotier[0]='default'
 
 # Commit all changes
-uci commit
+uci commit zerotier

--- a/zerotier/files/etc/uci-defaults/80-zt-migration
+++ b/zerotier/files/etc/uci-defaults/80-zt-migration
@@ -1,0 +1,17 @@
+# Convert the join list into networks
+nets=$(uci get zerotier.@zerotier[0].join)
+for net in ${nets}; do
+  sid=$(uci add zerotier network)
+  uci set zerotier.${sid}.id=${net}
+done
+uci delete zerotier.@zerotier[0].join
+
+# Rename local conf (only if defined)
+uci rename zerotier.@zerotier[0].local_conf='local_conf_path' \
+ > /dev/null 2>&1 || true
+
+# Rename configuration to default
+uci rename zerotier.@zerotier[0]='default'
+
+# Commit all changes
+uci commit

--- a/zerotier/files/etc/uci-defaults/80-zt-migration
+++ b/zerotier/files/etc/uci-defaults/80-zt-migration
@@ -3,6 +3,7 @@ nets=$(uci get zerotier.@zerotier[0].join)
 for net in ${nets}; do
   sid=$(uci add zerotier network)
   uci set zerotier.${sid}.id=${net}
+  uci set zerotier.${sid}.enabled=1
 done
 uci delete zerotier.@zerotier[0].join
 
@@ -10,8 +11,8 @@ uci delete zerotier.@zerotier[0].join
 uci rename zerotier.@zerotier[0].local_conf='local_conf_path' \
  > /dev/null 2>&1 || true
 
-# Rename configuration to default
-uci rename zerotier.@zerotier[0]='default'
+# Rename configuration to global
+uci rename zerotier.@zerotier[0]='global'
 
 # Commit all changes
 uci commit zerotier


### PR DESCRIPTION
Just add the configuration migration script to the new model introduced in #120

The script is quite simple. It generates the new `network` entries from the `join` list, renames it to `local_conf` (which with the new configuration is called `local_conf_path`) and renames the configuration to `default` so that it is loaded correctly by the new init script.

All this is done with the user's first configuration. If the user has more than one configuration for having several instances up (something quite unlikely) the rest are simply ignored and it is up to the user to evaluate what he/she wants to do.