### PR TITLE
Adds the ability to activate and deactivate networks

### DIFF
--- a/zerotier/files/etc/config/zerotier
+++ b/zerotier/files/etc/config/zerotier
@@ -1,7 +1,7 @@
 
 config zerotier 'global'
 	# Sets whether ZeroTier is enabled or not
-	option enabled 0
+	option enabled '0'
 	# Sets the ZeroTier listening port (default 9993; set to 0 for random)
 	#option port '9993'
 	# Client secret (leave blank to generate a secret on first run)
@@ -18,9 +18,12 @@ config zerotier 'global'
 
 # Network configuration, you can have as many configurations as networks you
 # want to join (the network name is optional)
-config network 'mynet'
+config network 'earth'
 	# Identifier of the network you wish to join
 	option id '8056c2e21c000001'
+	# Sets whether this network is enabled or disabled. If it is not
+	# enabled ZeroTier will not join it.
+	option enabled '1'
 	# Network configuration parameters (all are optional, if not indicated the
 	# default values are set, see documentation at
 	# https://docs.zerotier.com/config/#network-specific-configuration)
@@ -32,6 +35,7 @@ config network 'mynet'
 # Example of a second network (unnamed as it is optional)
 #config network
 #	option id '1234567890123456'
+#	option enabled '0'
 #	option allow_managed '1'
 #	option allow_global '0'
 #	option allow_default '0'

--- a/zerotier/files/etc/init.d/zerotier
+++ b/zerotier/files/etc/init.d/zerotier
@@ -9,15 +9,16 @@ CONFIG_PATH=/var/lib/zerotier-one
 
 join_network() {
 	local section="${1}"
-	local id allow_managed allow_global allow_default allow_dns
+	local id enabled allow_managed allow_global allow_default allow_dns
 
 	config_get id "${section}" 'id'
+	config_get_bool enabled "${section}" 'enabled' 1
 	config_get_bool allow_managed "${section}" 'allow_managed' 1
 	config_get_bool allow_global "${section}" 'allow_global' 0
 	config_get_bool allow_default "${section}" 'allow_default' 0
 	config_get_bool allow_dns "${section}" 'allow_dns' 0
 
-	if [ -n "${id}" ]; then
+	if [ -n "${id}" -a ${enabled} -eq 1 ]; then
 		# an (empty) config file will cause ZT to join a network
 		touch "${CONFIG_PATH}"/networks.d/"${id}".conf
 		echo "allowManaged=${allow_managed}" > "${CONFIG_PATH}"/networks.d/"${id}".local.conf
@@ -41,6 +42,7 @@ start_service() {
 
 	if [ ${enabled} -eq 0 ]; then
 		echo "disabled in /etc/config/zerotier"
+		return
 	fi
 
 	# Remove existing link or folder


### PR DESCRIPTION
With this change we allow the user to have networks configured in the configuration file but not enabled. I upload right now the change to the migration script to see if we can include it in the merge request that we have pending in the upstream.