### PR TITLE
Updates to 1.14.1

### DIFF
--- a/zerotier/Makefile
+++ b/zerotier/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
-PKG_VERSION:=1.14.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.14.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=7191623a81b0d1b552b9431e8864dd3420783ee518394ac1376cee6aaf033291
+PKG_HASH:=4f9f40b27c5a78389ed3f3216c850921f6298749e5819e9f2edabb2672ce9ca0
 PKG_BUILD_DIR:=$(BUILD_DIR)/ZeroTierOne-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>

--- a/zerotier/patches/0002-remove-PIE-options.patch
+++ b/zerotier/patches/0002-remove-PIE-options.patch
@@ -1,6 +1,6 @@
 From c10b5ed4c6c44e36178b0a5a82da9e8eaa957008 Mon Sep 17 00:00:00 2001
 From: Moritz Warning <moritzwarning@web.de>
-Date: Mon, 6 May 2024 22:34:15 +0200
+Date: Tue, 17 Sep 2024 11:50:37 +0200
 Subject: [PATCH 2/5] remove PIE options
 
 Signed-off-by: Moritz Warning <moritzwarning@web.de>
@@ -10,16 +10,16 @@ Signed-off-by: Moritz Warning <moritzwarning@web.de>
 
 --- a/make-linux.mk
 +++ b/make-linux.mk
-@@ -71,7 +71,7 @@ else
+@@ -71,7 +71,7 @@
  	override CFLAGS+=-Wall -Wno-deprecated -pthread $(INCLUDES) -DNDEBUG $(DEFS)
  	CXXFLAGS?=-O3 -fstack-protector
  	override CXXFLAGS+=-Wall -Wno-deprecated -std=c++17 -pthread $(INCLUDES) -DNDEBUG $(DEFS)
--	LDFLAGS=-pie -Wl,-z,relro,-z,now
-+	LDFLAGS=-Wl,-z,relro,-z,now
+-	LDFLAGS?=-pie -Wl,-z,relro,-z,now
++	LDFLAGS?=-Wl,-z,relro,-z,now
  	ZT_CARGO_FLAGS=--release
  endif
  
-@@ -333,7 +333,7 @@ ifeq ($(ZT_CONTROLLER),1)
+@@ -333,7 +333,7 @@
  endif
  
  # ARM32 hell -- use conservative CFLAGS
@@ -28,7 +28,7 @@ Signed-off-by: Moritz Warning <moritzwarning@web.de>
  	ifeq ($(shell if [ -e /usr/bin/dpkg ]; then dpkg --print-architecture; fi),armel)
  		override CFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
  		override CXXFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
-@@ -360,8 +360,8 @@ ifeq ($(ZT_USE_ARM32_NEON_ASM_CRYPTO),1)
+@@ -360,8 +360,8 @@
  endif
  
  # Position Independence
@@ -38,4 +38,4 @@ Signed-off-by: Moritz Warning <moritzwarning@web.de>
 +#override CXXFLAGS+=-fPIC -fPIE
  
  # Non-executable stack
- override ASFLAGS+=--noexecstack
+ override LDFLAGS+=-Wl,-z,noexecstack

--- a/zerotier/patches/0005-remove-noexecstack.patch
+++ b/zerotier/patches/0005-remove-noexecstack.patch
@@ -1,6 +1,6 @@
 From 2a5a279ac0192bc444cd1c3059169f576817d8b9 Mon Sep 17 00:00:00 2001
 From: Moritz Warning <moritzwarning@web.de>
-Date: Mon, 28 Aug 2023 09:48:28 +0200
+Date: Tue, 17 Sep 2024 11:50:37 +0200
 Subject: [PATCH 5/5] remove noexecstack
 
 The compilers for arm_cortex-a9 do not recognize this argument.
@@ -10,12 +10,12 @@ The compilers for arm_cortex-a9 do not recognize this argument.
 
 --- a/make-linux.mk
 +++ b/make-linux.mk
-@@ -364,7 +364,7 @@ endif
+@@ -364,7 +364,7 @@
  #override CXXFLAGS+=-fPIC -fPIE
  
  # Non-executable stack
--override ASFLAGS+=--noexecstack
-+# override ASFLAGS+=--noexecstack
+-override LDFLAGS+=-Wl,-z,noexecstack
++override LDFLAGS+=-Wl,-z
  
  .PHONY: all
  all:	one


### PR DESCRIPTION
I have tried to update the package to 1.14.1 but unfortunately it does not compile. It seems to have some problem with AES:
```
mipsel-openwrt-linux-musl-g++ -Os -pipe -mno-branch-likely -mips32r2 -mtune=24kc -fno-caller-saves -fno-plt -fhonour-copts -msoft-float -fmacro-prefix-map=/data/build_dir/target-mipsel_24kc_musl/ZeroTierOne-1.14.1=ZeroTierOne-1.14.1 -mips16 -minterlink-mips16 -ffunction-sections -fdata-sections -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -Wl,-z,noexecstack -mips16 -minterlink-mips16 -ffunction-sections -fdata-sections  -I/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/usr/include -I/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/include -I/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/include/fortify  -Wall -Wno-deprecated -std=c++17 -pthread -Irustybits/target -isystem ext -Iext/prometheus-cpp-lite-1.0/core/include -Iext-prometheus-cpp-lite-1.0/3rdparty/http-client-lite/include -Iext/prometheus-cpp-lite-1.0/simpleapi/include -DNDEBUG -DZT_USE_MINIUPNPC -DZT_USE_SYSTEM_MINIUPNPC -DZT_USE_SYSTEM_NATPMP -DZT_NO_TYPE_PUNNING -DZT_BUILD_PLATFORM=1 -DZT_BUILD_ARCHITECTURE=5 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -D_MT_ALLOCATOR_H -D_POOL_ALLOCATOR_H -D_EXTPTR_ALLOCATOR_H -D_DEBUG_ALLOCATOR_H -L/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/usr/lib -L/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib -fuse-ld=bfd -Wl,--gc-sections -znow -zrelro -Wl,--as-needed -Wl,-z,noexecstack  -Wl,-z -o zerotier-one node/AES.o node/AES_aesni.o node/AES_armcrypto.o node/C25519.o node/Capability.o node/CertificateOfMembership.o node/CertificateOfOwnership.o node/Identity.o node/IncomingPacket.o node/InetAddress.o node/Membership.o node/Metrics.o node/Multicaster.o node/Network.o node/NetworkConfig.o node/Node.o node/OutboundMulticast.o node/Packet.o node/Path.o node/Peer.o node/Poly1305.o node/Revocation.o node/Salsa20.o node/SelfAwareness.o node/SHA512.o node/Switch.o node/Tag.o node/Topology.o node/Trace.o node/Utils.o node/Bond.o node/PacketMultiplexer.o controller/EmbeddedNetworkController.o controller/DBMirrorSet.o controller/DB.o controller/FileDB.o controller/LFDB.o controller/PostgreSQL.o osdep/EthernetTap.o osdep/ManagedRoute.o osdep/Http.o osdep/OSUtils.o service/SoftwareUpdater.o service/OneService.o osdep/LinuxEthernetTap.o osdep/LinuxNetLink.o osdep/PortMapper.o ext/http-parser/http_parser.o one.o -latomic -lminiupnpc -lnatpmp
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: warning: -z node/AES.o ignored
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: node/Packet.o: in function `ZeroTier::Packet::armor(void const*, bool, ZeroTier::AES const*)':
Packet.cpp:(.text._ZN8ZeroTier6Packet5armorEPKvbPKNS_3AESE+0x5e): undefined reference to `ZeroTier::AES::GMAC::update(void const*, unsigned int)'
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: Packet.cpp:(.text._ZN8ZeroTier6Packet5armorEPKvbPKNS_3AESE+0x68): undefined reference to `ZeroTier::AES::GMAC::update(void const*, unsigned int)'
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: Packet.cpp:(.text._ZN8ZeroTier6Packet5armorEPKvbPKNS_3AESE+0x72): undefined reference to `ZeroTier::AES::GMAC::update(void const*, unsigned int)'
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: Packet.cpp:(.text._ZN8ZeroTier6Packet5armorEPKvbPKNS_3AESE+0x7a): undefined reference to `ZeroTier::AES::GMAC::finish(unsigned char*)'
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: Packet.cpp:(.text._ZN8ZeroTier6Packet5armorEPKvbPKNS_3AESE+0x94): undefined reference to `ZeroTier::AES::p_encryptSW(unsigned char const*, unsigned char*) const'
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: Packet.cpp:(.text._ZN8ZeroTier6Packet5armorEPKvbPKNS_3AESE+0xe6): undefined reference to `ZeroTier::AES::CTR::crypt(void const*, unsigned int)'
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: Packet.cpp:(.text._ZN8ZeroTier6Packet5armorEPKvbPKNS_3AESE+0xec): undefined reference to `ZeroTier::AES::CTR::finish()'
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: node/Packet.o: in function `ZeroTier::Packet::dearmor(void const*, ZeroTier::AES const*)':
Packet.cpp:(.text._ZN8ZeroTier6Packet7dearmorEPKvPKNS_3AESE+0xb6): undefined reference to `ZeroTier::AES::p_decryptSW(unsigned char const*, unsigned char*) const'
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: Packet.cpp:(.text._ZN8ZeroTier6Packet7dearmorEPKvPKNS_3AESE+0xf2): undefined reference to `ZeroTier::AES::GMAC::update(void const*, unsigned int)'
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: Packet.cpp:(.text._ZN8ZeroTier6Packet7dearmorEPKvPKNS_3AESE+0xfc): undefined reference to `ZeroTier::AES::GMAC::update(void const*, unsigned int)'
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: Packet.cpp:(.text._ZN8ZeroTier6Packet7dearmorEPKvPKNS_3AESE+0x10a): undefined reference to `ZeroTier::AES::CTR::crypt(void const*, unsigned int)'
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: Packet.cpp:(.text._ZN8ZeroTier6Packet7dearmorEPKvPKNS_3AESE+0x118): undefined reference to `ZeroTier::AES::CTR::finish()'
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: Packet.cpp:(.text._ZN8ZeroTier6Packet7dearmorEPKvPKNS_3AESE+0x122): undefined reference to `ZeroTier::AES::GMAC::update(void const*, unsigned int)'
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: Packet.cpp:(.text._ZN8ZeroTier6Packet7dearmorEPKvPKNS_3AESE+0x12a): undefined reference to `ZeroTier::AES::GMAC::finish(unsigned char*)'
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: node/Peer.o: in function `ZeroTier::Peer::Peer(ZeroTier::RuntimeEnvironment const*, ZeroTier::Identity const&, ZeroTier::Identity const&)':
Peer.cpp:(.text._ZN8ZeroTier4PeerC2EPKNS_18RuntimeEnvironmentERKNS_8IdentityES6_+0x4f2): undefined reference to `ZeroTier::AES::p_initSW(unsigned char const*)'
/data/staging_dir/toolchain-mipsel_24kc_gcc-13.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/13.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: Peer.cpp:(.text._ZN8ZeroTier4PeerC2EPKNS_18RuntimeEnvironmentERKNS_8IdentityES6_+0x50e): undefined reference to `ZeroTier::AES::p_initSW(unsigned char const*)'
collect2: error: ld returned 1 exit status
make[3]: *** [make-linux.mk:380: zerotier-one] Error 1
```

It is possible that the problem is in the upstream code, but it was just in case you could think of something @mwarning 